### PR TITLE
Make clientid actually clientid. Add state.Name

### DIFF
--- a/glcd-handlers.lua
+++ b/glcd-handlers.lua
@@ -1,4 +1,4 @@
-inspect = require("library/inspect")
+local inspect = require("library/inspect")
 
 function onChat(v)
   if not v.Sender then
@@ -32,9 +32,12 @@ function onPlayerState(v)
   if clientid == nil then
     -- error from the server? we shouldn't see this
     print("error: onplayerstate information was empty")
-  elseif clientid ~= glcd.name then
+  elseif clientid ~= glcd.clientid then
     if otherPlayers[clientid] == nil then
       otherPlayers[clientid] = {name=clientid}
+      if v.Name then
+        otherPlayers[clientid].name = v.Name
+      end
     end
     otherPlayers[clientid].state = v
   end

--- a/main.lua
+++ b/main.lua
@@ -19,7 +19,9 @@ function love.load()
   console.log("** starting game lost crash client")
   console.show()
 
-  myState = {}
+  myState = {
+    Name = glcd.name
+  }
   stateChanged = true
 
   myPlayer = {


### PR DESCRIPTION
Client ID should eventually be unique among all clients, while Name
is likely to eventually be cosmetic (think unicode, etc).

Until glcd is updated, people will see "<ip>-<name>" temporarily,
then should start seeing "Name" again once glcd's PlayerState groks
Names.
