### PR TITLE
Possibly better separation

### DIFF
--- a/graphics/sprites/bullet.lua
+++ b/graphics/sprites/bullet.lua
@@ -47,14 +47,13 @@ local function fireBullet(playerData)
 end
 
 Bullet = Sprite.inherit{spriteType = "Bullet"}
-Bullet.__index = Bullet
 Bullet.fireBullet = fireBullet
 
-function Bullet:updateState(data)
+function Bullet.fn:updateState(data)
   self.speed = data.speed or self.speed
 end
 
-function Bullet:update()
+function Bullet.fn:update()
 
   -- for now
   local delta = 0.4
@@ -84,7 +83,7 @@ function Bullet:update()
   -- end
 end
 
-function Bullet:draw()
+function Bullet.fn:draw()
   layers.background:draw(drawBullet, {self.x, self.y})
 end
 
@@ -98,7 +97,7 @@ function Bullet.new(obj)
     zoneid = obj.zoneid
   }
 
-  self = Bullet.__base.new(bulletData)
+  self = Sprite.new(bulletData)
   setmetatable(self, Bullet)
   self:updateState(obj)
   return self

--- a/graphics/sprites/player.lua
+++ b/graphics/sprites/player.lua
@@ -147,10 +147,8 @@ local function setAvatar(file)
 end
 
 local function changeAvatar(id)
-  local keys = {}
-  local n    = 0
-  local first = nil
-  local ret = false
+  local keys, n, first, ret =
+          {}, 0, nil, false
   for k, v in pairs(avatars) do
     n = n + 1
     keys[n] = k
@@ -167,21 +165,18 @@ local function changeAvatar(id)
   return first
 end
 
-Player = Sprite.inherit{spriteType = "Player"}
-Player.__index = Player
+local Player = Sprite.inherit{
+  spriteType = "Player",
+  changeAvatar = changeAvatar,
+}
 Player.setAvatar = setAvatar
-Player.changeAvatar = changeAvatar
 
-function Player:update()
-  -- no-op.
-end
-
-function Player:draw()
+function Player.fn.draw(self)
   layers.background:draw(drawPlayer, {self})
   layers.text:draw(drawPlayerAttributes, {self})
 end
 
-function Player:updateState(data)
+function Player.fn.updateState(self, data)
   self.avatarid = data.AvatarId or self.avatarid
   self.avatarstate = data.AvatarState or self.avatarstate
   self.hitPoint = data.hitPoint or self.hitPoint
@@ -196,16 +191,15 @@ function Player:updateState(data)
   }
 
   -- we must manually call the base function; we can't use :.
-  self.__base.updateState(self, baseState)
+  Player.__base.updateState(self, baseState)
 end
 
 -- TODO
 -- current zone id -- needs to be checked universally (except for Player)
 
 function Player.new(obj)
-
   -- for now, until we get the whole capitalization mess sorted out, ugh
-  spriteData = {
+  local spriteData = {
     x = obj.X,
     y = obj.Y,
     width = obj.width,
@@ -213,8 +207,8 @@ function Player.new(obj)
     direction = obj.direction,
     zoneid = obj.zoneid
   }
-  self = Player.__base.new(spriteData)
-  setmetatable(self, Player)
+  local self = Sprite.new(spriteData)
+  self = setmetatable(self, Player)
   self:updateState(obj)
   return self
 end

--- a/graphics/sprites/sprite.lua
+++ b/graphics/sprites/sprite.lua
@@ -1,41 +1,35 @@
-aabb = require('geometry/aabb')
-vector = require('geometry/vector')
+local aabb = require('geometry/aabb')
+local vector = require('geometry/vector')
+local _ = require('util/underscore')
 
 -- generic sprite class.
-Sprite = {}
-Sprite.__index = Sprite
+local prototype = {
+  -- each sprite must implement:
+  --   updateState = function(self, data)
+  --   update = function(self)
+  --   draw = function(self)
+  updateState = function(self, data)
+    -- each sprite has the following attributes:
+    --   world coordinates (x, y)
+    --   width, height
+    --   zone id
+    --   direction (can be nil)
+    --   axis-aligned bounding box (automatically calculated)
+    self.x = data.x or self.x
+    self.y = data.y or self.y
+    self.width = data.width or self.width
+    self.height = data.height or self.height
+    self.direction = data.direction or self.direction
+    self.zoneid = data.zoneid or self.zoneid
+  end,
+  update = function (self)
+  end,
+  draw = function (self)
+  end,
+}
 
--- each sprite must implement:
---   updateState = function(self, data)
---   update = function(self)
---   draw = function(self)
-
-function Sprite:update()
-  assert(false, "base sprite `update' function called.")
-end
-
-function Sprite:draw()
-  assert(false, "base sprite `draw' function called.")
-end
-
--- each sprite has the following attributes:
---   world coordinates (x, y)
---   width, height
---   zone id
---   direction (can be nil)
---   axis-aligned bounding box (automatically calculated)
-
-function Sprite:updateState(data)
-  self.x = data.x or self.x
-  self.y = data.y or self.y
-  self.width = data.width or self.width
-  self.height = data.height or self.height
-  self.direction = data.direction or self.direction
-  self.zoneid = data.zoneid or self.zoneid
-end
-
-function Sprite.new(args)
-  self = setmetatable({}, Sprite)
+local new = function(args)
+  local self = setmetatable(args, {__index = prototype})
 
   -- required
   self.width = args.width
@@ -59,15 +53,21 @@ function Sprite.new(args)
   return self
 end
 
--- inheritance function.
-function Sprite.inherit(args)
-  superclass = {}
-  superclass.spriteType = args.spriteType or "Unknown"
-  superclass.__base = Sprite
-  -- these must be overridden.
-  superclass.draw = superclass.__base.draw
-  superclass.update = superclass.__base.update
-  return superclass
+local inherit
+
+inherit = function(args)
+  extension = _.extend(args, prototype)
+  return {
+    new = new,
+    __base = prototype,
+    __index = extension,
+    inherit = inherit,
+    fn = extension,
+  }
 end
 
-return Sprite
+return {
+  inherit = inherit,
+  fn = prototype,
+  new = new,
+}

--- a/spec/sprite_spec.lua
+++ b/spec/sprite_spec.lua
@@ -1,38 +1,53 @@
 local Sprite = require('graphics/sprites/sprite')
+local _ = require('util/underscore')
 
 describe('Sprite', function()
+  local sprite
   it("Sprite.new creates an instance when passed width, height, and zoneid", function()
     assert(Sprite.new{width=20,height=20,zoneid=1})
   end)
 
   describe("New Sprite", function()
-    -- it("has spriteUpdate", function()
-    --   sprite = Sprite.new{width=20,height=20,zoneid=1}
-    --   assert(sprite:spriteUpdate(), "can call spriteUpdate")
-    -- end)
-    -- it("spriteUpdate requires update function", function()
-    --   sprite = Sprite.new{width=20,
-    --   height=20,
-    --   zoneid=1,
-    --   update=function()
-    --   end}
-    --   assert(sprite:spriteUpdate(), "can call spriteUpdate")
-    -- end)
+    args = {width=20,height=20,zoneid=1}
+    it("is endued with update", function()
+      sprite = Sprite.new(args)
+      assert(sprite.update, "can call update")
+    end)
+    it("is endued with draw", function()
+      assert(sprite.draw, "can call update")
+    end)
+    it("is endued with updateState", function()
+      assert(sprite.updateState, "can call update")
+    end)
+
+    it("overriding a function is possible", function()
+      local with_update = _.extend({update=function()
+        return 5
+      end}, args)
+      sprite = Sprite.new(with_update)
+      assert(sprite:update() == 5, "can call update")
+    end)
   end)
 
   describe("Sprite.inherit", function()
-
-    -- Need to be cautious here. When extending from Sprite, we are losing the
-    -- ability to call setmetatable, which MUST have __index
-    default_data = {width=20,height=20,zoneid=1}
-    it("Inheriting from Sprite can still call new", function()
-      Player = Sprite.inherit{drawPlayer=function() end}
-      Player.new = function(args)
-        -- set up original Sprite data and then set metatable
-        obj = Sprite.new(args)
-        return setmetatable(args,Player)
-      end
-      assert(Player.new(default_data))
+    local default_data = {width=20,height=20,zoneid=1}
+    local Player = Sprite.inherit{drawPlayer=function() end}
+    Player.new = function(args)
+      -- set up original Sprite data and then set metatable
+      local obj = Sprite.new(args)
+      return setmetatable(args, Player)
+    end
+    it("from Sprite can still call new", function()
+      assert(Player.new(default_data), "it didn't work")
     end)
+    it("drawPlayer", function()
+      local p = Player.new(default_data)
+      assert(p.drawPlayer, "couldn't be called")
+    end)
+
+    it("__base prototype", function()
+      assert(Player.__base, "doesn't exist")
+    end)
+
   end)
 end)


### PR DESCRIPTION
So-Called Reveal Module

I also modify to make __index refer to extended type so that it can also
be used as is. My goal was to make it easy for me to see how I might
extend and add to a prototype without overriding the Sprite using
underscore.
